### PR TITLE
add warning about app/assets/

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This will install a configuration file (`.bowerrc`) in your project's root. The 
 
 ```
 
-Add your dependencies to `bower.json` or use `bower install` as you would in any other project.
+You can change the destination directory if you like, though putting Bower components under `app/assets/` can cause problems (see [rails/rails#7968](https://github.com/rails/rails/pull/7968)). Add your dependencies to `bower.json` or use `bower install` as you would in any other project.
 
 ### Non-Rails Projects
 


### PR DESCRIPTION
Because of https://github.com/sstephenson/sprockets/issues/347, Rails will complain if it tries to compile files without extensions. https://github.com/rails/rails/pull/7968 made it so `app/assets/` is the only directory that gets precompiled by default, so added a warning to not use this.

FYI, I'm now recommending this gem in [my Bower+Heroku guide](https://gist.github.com/afeld/5704079/). Nice work!
