### PR TITLE
Add dependency on MultiJSON

### DIFF
--- a/bower.gemspec
+++ b/bower.gemspec
@@ -15,4 +15,6 @@ Gem::Specification.new do |spec|
 
   spec.files = %w(.yardopts CHANGELOG.md LICENSE.md README.md bower.gemspec) + Dir['lib/**/*.rb']
   spec.require_paths = ['lib']
+
+  spec.add_runtime_dependency 'multi_json'
 end


### PR DESCRIPTION
Hi,

Thanks for the nice gem.

But I encountered the error below when executing rackup:

```
../vendor/bundle/ruby/2.2.0/gems/bower-0.0.3/lib/bower/environment.rb:1:in `require': cannot load such file -- multi_json (LoadError)
```

At minimal project rather than Rails, sometimes MultiJSON is not on dependency table.
Could you add it to bower.gemspec?
